### PR TITLE
fix(keyword-engine): Fix "object is not iterable" on activation

### DIFF
--- a/src/features/keyword-engine.ts
+++ b/src/features/keyword-engine.ts
@@ -28,7 +28,7 @@ export class KeywordEngine {
     ]);
 
     // 常用漢字セットの初期化
-    this.joyoKanjiSet = new Set(joyoKanji);
+    this.joyoKanjiSet = new Set(joyoKanji.kanji);
 
     // キーワード候補となるパターン
     this.keywordPatterns = [


### PR DESCRIPTION
The extension was failing to activate due to an "object is not iterable" error. This was caused by the `KeywordEngine` constructor attempting to create a `Set` from the entire `joyo-kanji` module object, instead of the `kanji` array property within that object.

This commit corrects the `Set` initialization to use `joyoKanji.kanji`, resolving the startup crash.