### PR TITLE
fix(keyword-engine): Use absolute path for kuromoji dictionary

### DIFF
--- a/src/features/analyzer.ts
+++ b/src/features/analyzer.ts
@@ -554,6 +554,14 @@ export async function initializeAnalyzer(context: vscode.ExtensionContext): Prom
     diagnosticCollection = vscode.languages.createDiagnosticCollection('criticalWritingJp');
     context.subscriptions.push(diagnosticCollection);
 
+    // キーワードエンジンの初期化（コンテキストを渡す）
+    try {
+      keywordEngine.initialize(context);
+      console.log('[Analyzer] Keyword engine context set');
+    } catch (error) {
+      console.warn('[Analyzer] Failed to set keyword engine context:', error);
+    }
+
     // 引用チェッカーのデフォルトスタイルを初期化
     try {
       citationChecker.initializeDefaultStyles();

--- a/src/features/keyword-engine.ts
+++ b/src/features/keyword-engine.ts
@@ -1,3 +1,5 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
 import { Paragraph, Keyword } from '../core/types';
 import { normalizeText } from '../core/utils';
 import * as kuromoji from 'kuromoji';
@@ -13,6 +15,7 @@ export class KeywordEngine {
   private tokenizer: kuromoji.Tokenizer | null = null;
   private joyoKanjiSet: Set<string>;
   private isInitialized = false;
+  private context: vscode.ExtensionContext | null = null;
 
   constructor() {
     // 日本語ストップワード（一般的すぎる語彙を除外）
@@ -28,7 +31,7 @@ export class KeywordEngine {
     ]);
 
     // 常用漢字セットの初期化
-    this.joyoKanjiSet = new Set(joyoKanji);
+    this.joyoKanjiSet = new Set(joyoKanji.kanji);
 
     // キーワード候補となるパターン
     this.keywordPatterns = [
@@ -41,6 +44,14 @@ export class KeywordEngine {
       // 「〜性」「〜化」「〜的」「〜論」などの学術用語的語尾
       /[\u4E00-\u9FAF]+[性化的論法則系]/g
     ];
+  }
+
+  /**
+   * 拡張機能のコンテキストをセット
+   * @param context 拡張機能コンテキスト
+   */
+  public initialize(context: vscode.ExtensionContext): void {
+    this.context = context;
   }
 
   /**
@@ -63,46 +74,33 @@ export class KeywordEngine {
           resolve();
         }, 10000);
 
-        // Try different possible dictionary paths
-        const possiblePaths = [
-          'node_modules/kuromoji/dict',
-          './node_modules/kuromoji/dict',
-          '../node_modules/kuromoji/dict',
-          '../../node_modules/kuromoji/dict'
-        ];
+        if (!this.context) {
+          console.error('[KeywordEngine] Extension context is not available. Cannot initialize tokenizer.');
+          clearTimeout(timeoutId);
+          this.isInitialized = true;
+          resolve();
+          return;
+        }
 
-        let currentPathIndex = 0;
-        
-        const tryNextPath = () => {
-          if (currentPathIndex >= possiblePaths.length) {
-            console.error('[KeywordEngine] All dictionary paths failed, falling back to rule-based extraction');
+        const dicPath = path.join(this.context.extensionPath, 'node_modules', 'kuromoji', 'dict');
+        console.log(`[KeywordEngine] Initializing kuromoji with dictionary path: ${dicPath}`);
+
+        kuromoji.builder({ dicPath }).build((err, tokenizer) => {
+          if (err) {
+            console.error(`[KeywordEngine] Failed to initialize kuromoji with path '${dicPath}':`, err);
+            console.log('[KeywordEngine] Falling back to rule-based extraction');
             clearTimeout(timeoutId);
             this.isInitialized = true;
             resolve();
             return;
           }
 
-          const dicPath = possiblePaths[currentPathIndex];
-          console.log(`[KeywordEngine] Trying dictionary path: ${dicPath}`);
-          currentPathIndex++;
-
-          kuromoji.builder({ dicPath }).build((err, tokenizer) => {
-            if (err) {
-              console.error(`[KeywordEngine] Failed with path '${dicPath}':`, err);
-              console.log('[KeywordEngine] Trying next dictionary path...');
-              tryNextPath();
-              return;
-            }
-            
-            console.log(`[KeywordEngine] Successfully initialized kuromoji with path: ${dicPath}`);
-            clearTimeout(timeoutId);
-            this.tokenizer = tokenizer;
-            this.isInitialized = true;
-            resolve();
-          });
-        };
-
-        tryNextPath();
+          console.log('[KeywordEngine] Successfully initialized kuromoji.');
+          clearTimeout(timeoutId);
+          this.tokenizer = tokenizer;
+          this.isInitialized = true;
+          resolve();
+        });
 
       } catch (error) {
         console.error('[KeywordEngine] Exception during tokenizer initialization:', error);


### PR DESCRIPTION
The keyword analysis was failing because the `kuromoji` tokenizer could not find its dictionary files. The previous implementation used fragile relative paths that break when the extension is installed.

This commit refactors the `KeywordEngine` to be initialized with the extension context. It now uses the `context.extensionPath` to construct a reliable, absolute path to the `kuromoji` dictionary located within the `node_modules` directory. This ensures the tokenizer can initialize correctly, allowing the analysis features to work as expected.