### PR TITLE
fix: Correct asset packaging and webview communication

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,5 +1,6 @@
 const { build } = require('esbuild');
-const { existsSync, mkdirSync } = require('fs');
+const fs = require('fs');
+const { existsSync, mkdirSync } = fs;
 const path = require('path');
 
 // コマンドライン引数解析
@@ -29,6 +30,43 @@ if (!existsSync(distDir)) {
   mkdirSync(distDir, { recursive: true });
 }
 
+function copyAssets() {
+  console.log('📂 Copying assets...');
+  try {
+    // Kuromoji辞書ファイルをコピー
+    const kuromojiSrc = path.resolve(__dirname, '..', 'node_modules', 'kuromoji', 'dict');
+    const kuromojiDest = path.resolve(__dirname, '..', 'dist', 'dict');
+    if (fs.existsSync(kuromojiSrc)) {
+      if (!fs.existsSync(kuromojiDest)) {
+        fs.mkdirSync(kuromojiDest, { recursive: true });
+      }
+      fs.cpSync(kuromojiSrc, kuromojiDest, { recursive: true });
+      console.log('  - Kuromoji dictionary copied to dist/dict');
+    } else {
+      console.warn('  - Kuromoji dictionary source not found, skipping copy.');
+    }
+
+    // webview-assetsをコピー
+    const webviewAssetsSrc = path.resolve(__dirname, '..', 'webview-assets');
+    const webviewAssetsDest = path.resolve(__dirname, '..', 'dist', 'webview-assets');
+    if (fs.existsSync(webviewAssetsSrc)) {
+      if (!fs.existsSync(webviewAssetsDest)) {
+        fs.mkdirSync(webviewAssetsDest, { recursive: true });
+      }
+      fs.cpSync(webviewAssetsSrc, webviewAssetsDest, { recursive: true });
+      console.log('  - Webview assets copied to dist/webview-assets');
+    } else {
+      // webview-assets はオプションではないので警告を出す
+      console.warn('  - webview-assets directory not found, skipping copy.');
+    }
+
+    console.log('  ✅ Assets copied successfully!');
+  } catch (error) {
+    console.error('  ❌ Asset copying failed:', error);
+    process.exit(1);
+  }
+}
+
 async function buildExtension() {
   try {
     console.log(`🔨 Building extension (${isDev ? 'development' : 'production'})...`);
@@ -50,6 +88,9 @@ async function buildExtension() {
       }
     }
     
+    // アセットをコピー
+    copyAssets();
+
     console.log('✅ Build completed successfully!');
     return result;
   } catch (error) {

--- a/src/features/keyword-engine.ts
+++ b/src/features/keyword-engine.ts
@@ -82,7 +82,7 @@ export class KeywordEngine {
           return;
         }
 
-        const dicPath = path.join(this.context.extensionPath, 'node_modules', 'kuromoji', 'dict');
+        const dicPath = path.join(this.context.extensionPath, 'dist', 'dict');
         console.log(`[KeywordEngine] Initializing kuromoji with dictionary path: ${dicPath}`);
 
         kuromoji.builder({ dicPath }).build((err, tokenizer) => {

--- a/src/features/webview-panel.ts
+++ b/src/features/webview-panel.ts
@@ -141,6 +141,10 @@ export class WebviewPanel {
         await this.handleGoogleBooksConfigRequest();
         break;
 
+      case 'refreshAnalysis':
+        await vscode.commands.executeCommand('criticalWritingJp.runKeywordNow');
+        break;
+
       default:
         console.warn(`[WebviewPanel] Unknown message command: ${message.command}`);
     }


### PR DESCRIPTION
This commit resolves two critical issues preventing the analysis panel from functioning correctly.

1.  **Asset Packaging:** The `kuromoji` dictionary files and `webview-assets` were not being included in the final extension package (`.vsix`). The build script (`scripts/build.js`) has been updated to copy these necessary assets into the `dist` directory during the build. The `keyword-engine` has also been updated to locate the dictionary using a reliable, absolute path derived from the extension context.

2.  **Webview Communication:** The analysis panel was not displaying results because it could not trigger a re-analysis. A message handler for the `refreshAnalysis` command was missing. This has been added to `webview-panel.ts`, restoring the communication link between the UI and the extension's backend.