### PR TITLE
fix: Track active editor and include missing assets

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,5 +1,6 @@
 const { build } = require('esbuild');
-const { existsSync, mkdirSync } = require('fs');
+const fs = require('fs');
+const { existsSync, mkdirSync } = fs;
 const path = require('path');
 
 // コマンドライン引数解析
@@ -29,6 +30,43 @@ if (!existsSync(distDir)) {
   mkdirSync(distDir, { recursive: true });
 }
 
+function copyAssets() {
+  console.log('📂 Copying assets...');
+  try {
+    // Kuromoji辞書ファイルをコピー
+    const kuromojiSrc = path.resolve(__dirname, '..', 'node_modules', 'kuromoji', 'dict');
+    const kuromojiDest = path.resolve(__dirname, '..', 'dist', 'dict');
+    if (fs.existsSync(kuromojiSrc)) {
+      if (!fs.existsSync(kuromojiDest)) {
+        fs.mkdirSync(kuromojiDest, { recursive: true });
+      }
+      fs.cpSync(kuromojiSrc, kuromojiDest, { recursive: true });
+      console.log('  - Kuromoji dictionary copied to dist/dict');
+    } else {
+      console.warn('  - Kuromoji dictionary source not found, skipping copy.');
+    }
+
+    // webview-assetsをコピー
+    const webviewAssetsSrc = path.resolve(__dirname, '..', 'webview-assets');
+    const webviewAssetsDest = path.resolve(__dirname, '..', 'dist', 'webview-assets');
+    if (fs.existsSync(webviewAssetsSrc)) {
+      if (!fs.existsSync(webviewAssetsDest)) {
+        fs.mkdirSync(webviewAssetsDest, { recursive: true });
+      }
+      fs.cpSync(webviewAssetsSrc, webviewAssetsDest, { recursive: true });
+      console.log('  - Webview assets copied to dist/webview-assets');
+    } else {
+      // webview-assets はオプションではないので警告を出す
+      console.warn('  - webview-assets directory not found, skipping copy.');
+    }
+
+    console.log('  ✅ Assets copied successfully!');
+  } catch (error) {
+    console.error('  ❌ Asset copying failed:', error);
+    process.exit(1);
+  }
+}
+
 async function buildExtension() {
   try {
     console.log(`🔨 Building extension (${isDev ? 'development' : 'production'})...`);
@@ -50,6 +88,9 @@ async function buildExtension() {
       }
     }
     
+    // アセットをコピー
+    copyAssets();
+
     console.log('✅ Build completed successfully!');
     return result;
   } catch (error) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import { Settings } from './platform/settings';
 import { initializeAnalyzer } from './features/analyzer';
 
 let globalSettings: Settings;
+let lastActiveMarkdownEditor: vscode.TextEditor | undefined;
 
 /**
  * 拡張機能のアクティベーション
@@ -12,6 +13,11 @@ let globalSettings: Settings;
 export function activate(context: vscode.ExtensionContext) {
   console.log('[CriticalWritingJp] Activating extension...');
   
+  // 初期アクティブエディタを設定
+  if (vscode.window.activeTextEditor && vscode.window.activeTextEditor.document.languageId === 'markdown') {
+    lastActiveMarkdownEditor = vscode.window.activeTextEditor;
+  }
+
   const startTime = Date.now();
   const store = new DisposableStore();
   context.subscriptions.push(store);
@@ -182,8 +188,7 @@ function registerConfigureGoogleBooksKeyCommand(store: DisposableStore, context:
 function registerRunKeywordNowCommand(store: DisposableStore) {
   store.add(vscode.commands.registerCommand('criticalWritingJp.runKeywordNow', async () => {
     try {
-      const editor = vscode.window.activeTextEditor;
-      if (!editor || editor.document.languageId !== 'markdown') {
+      if (!lastActiveMarkdownEditor || lastActiveMarkdownEditor.document.isClosed) {
         vscode.window.showWarningMessage('Markdownファイルを開いてください');
         return;
       }
@@ -191,7 +196,7 @@ function registerRunKeywordNowCommand(store: DisposableStore) {
       vscode.window.showInformationMessage('キーワード解析を実行中...');
       // 実際の解析処理は遅延ロード
       const { runAnalysis } = await import('./features/analyzer');
-      await runAnalysis(editor.document);
+      await runAnalysis(lastActiveMarkdownEditor.document);
       vscode.window.showInformationMessage('キーワード解析が完了しました');
     } catch (error) {
       console.error('[CriticalWritingJp] Failed to run keyword analysis:', error);
@@ -267,6 +272,7 @@ function registerTextDocumentHandlers(store: DisposableStore, context: vscode.Ex
       if (!editor || editor.document.languageId !== 'markdown') {
         return;
       }
+      lastActiveMarkdownEditor = editor;
 
       // 新しいMarkdownファイルが開かれた時の初期解析
       const { runAnalysis } = await import('./features/analyzer');

--- a/src/features/analyzer.ts
+++ b/src/features/analyzer.ts
@@ -554,6 +554,14 @@ export async function initializeAnalyzer(context: vscode.ExtensionContext): Prom
     diagnosticCollection = vscode.languages.createDiagnosticCollection('criticalWritingJp');
     context.subscriptions.push(diagnosticCollection);
 
+    // キーワードエンジンの初期化（コンテキストを渡す）
+    try {
+      keywordEngine.initialize(context);
+      console.log('[Analyzer] Keyword engine context set');
+    } catch (error) {
+      console.warn('[Analyzer] Failed to set keyword engine context:', error);
+    }
+
     // 引用チェッカーのデフォルトスタイルを初期化
     try {
       citationChecker.initializeDefaultStyles();

--- a/src/features/keyword-engine.ts
+++ b/src/features/keyword-engine.ts
@@ -1,3 +1,5 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
 import { Paragraph, Keyword } from '../core/types';
 import { normalizeText } from '../core/utils';
 import * as kuromoji from 'kuromoji';
@@ -13,6 +15,7 @@ export class KeywordEngine {
   private tokenizer: kuromoji.Tokenizer | null = null;
   private joyoKanjiSet: Set<string>;
   private isInitialized = false;
+  private context: vscode.ExtensionContext | null = null;
 
   constructor() {
     // 日本語ストップワード（一般的すぎる語彙を除外）
@@ -28,7 +31,7 @@ export class KeywordEngine {
     ]);
 
     // 常用漢字セットの初期化
-    this.joyoKanjiSet = new Set(joyoKanji);
+    this.joyoKanjiSet = new Set(joyoKanji.kanji);
 
     // キーワード候補となるパターン
     this.keywordPatterns = [
@@ -41,6 +44,14 @@ export class KeywordEngine {
       // 「〜性」「〜化」「〜的」「〜論」などの学術用語的語尾
       /[\u4E00-\u9FAF]+[性化的論法則系]/g
     ];
+  }
+
+  /**
+   * 拡張機能のコンテキストをセット
+   * @param context 拡張機能コンテキスト
+   */
+  public initialize(context: vscode.ExtensionContext): void {
+    this.context = context;
   }
 
   /**
@@ -63,46 +74,33 @@ export class KeywordEngine {
           resolve();
         }, 10000);
 
-        // Try different possible dictionary paths
-        const possiblePaths = [
-          'node_modules/kuromoji/dict',
-          './node_modules/kuromoji/dict',
-          '../node_modules/kuromoji/dict',
-          '../../node_modules/kuromoji/dict'
-        ];
+        if (!this.context) {
+          console.error('[KeywordEngine] Extension context is not available. Cannot initialize tokenizer.');
+          clearTimeout(timeoutId);
+          this.isInitialized = true;
+          resolve();
+          return;
+        }
 
-        let currentPathIndex = 0;
-        
-        const tryNextPath = () => {
-          if (currentPathIndex >= possiblePaths.length) {
-            console.error('[KeywordEngine] All dictionary paths failed, falling back to rule-based extraction');
+        const dicPath = path.join(this.context.extensionPath, 'dist', 'dict');
+        console.log(`[KeywordEngine] Initializing kuromoji with dictionary path: ${dicPath}`);
+
+        kuromoji.builder({ dicPath }).build((err, tokenizer) => {
+          if (err) {
+            console.error(`[KeywordEngine] Failed to initialize kuromoji with path '${dicPath}':`, err);
+            console.log('[KeywordEngine] Falling back to rule-based extraction');
             clearTimeout(timeoutId);
             this.isInitialized = true;
             resolve();
             return;
           }
 
-          const dicPath = possiblePaths[currentPathIndex];
-          console.log(`[KeywordEngine] Trying dictionary path: ${dicPath}`);
-          currentPathIndex++;
-
-          kuromoji.builder({ dicPath }).build((err, tokenizer) => {
-            if (err) {
-              console.error(`[KeywordEngine] Failed with path '${dicPath}':`, err);
-              console.log('[KeywordEngine] Trying next dictionary path...');
-              tryNextPath();
-              return;
-            }
-            
-            console.log(`[KeywordEngine] Successfully initialized kuromoji with path: ${dicPath}`);
-            clearTimeout(timeoutId);
-            this.tokenizer = tokenizer;
-            this.isInitialized = true;
-            resolve();
-          });
-        };
-
-        tryNextPath();
+          console.log('[KeywordEngine] Successfully initialized kuromoji.');
+          clearTimeout(timeoutId);
+          this.tokenizer = tokenizer;
+          this.isInitialized = true;
+          resolve();
+        });
 
       } catch (error) {
         console.error('[KeywordEngine] Exception during tokenizer initialization:', error);

--- a/src/features/webview-panel.ts
+++ b/src/features/webview-panel.ts
@@ -141,6 +141,10 @@ export class WebviewPanel {
         await this.handleGoogleBooksConfigRequest();
         break;
 
+      case 'refreshAnalysis':
+        await vscode.commands.executeCommand('criticalWritingJp.runKeywordNow');
+        break;
+
       default:
         console.warn(`[WebviewPanel] Unknown message command: ${message.command}`);
     }

--- a/webview-assets/styles.css
+++ b/webview-assets/styles.css
@@ -1,0 +1,38 @@
+/* Basic styles for the webview panel */
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  padding: 1em;
+  color: var(--vscode-editor-foreground);
+  background-color: var(--vscode-editor-background);
+}
+
+h1, h3 {
+  color: var(--vscode-textLink-foreground);
+}
+
+button {
+  background-color: var(--vscode-button-background);
+  color: var(--vscode-button-foreground);
+  border: 1px solid var(--vscode-button-border, transparent);
+  padding: 0.5em 1em;
+  cursor: pointer;
+}
+
+button:hover {
+  background-color: var(--vscode-button-hoverBackground);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th, td {
+  border: 1px solid var(--vscode-editorWidget-border);
+  padding: 8px;
+  text-align: left;
+}
+
+th {
+  background-color: var(--vscode-editorWidget-background);
+}


### PR DESCRIPTION
This commit resolves issues that prevented the analysis from running correctly.

1.  **Active Editor Tracking:** The "Re-Analyze Now" command failed because `activeTextEditor` was undefined when the webview panel had focus. The extension now tracks the last-known active markdown editor and uses it as the target for analysis, making the feature robust.

2.  **Missing CSS Asset:** A `webview-assets/styles.css` file was missing from the project, causing a 404 error in the webview. The file has been created, and the build script will now correctly package it.