### PR TITLE
feat: MDファイルを開いた際に分析パネルを表示

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -389,11 +389,13 @@ function registerTextDocumentHandlers(store: DisposableStore, context: vscode.Ex
       }
       lastActiveMarkdownEditor = editor;
 
+      // パネルを表示
+      const { createOrShowPanel } = await import('./features/webview-panel');
+      await createOrShowPanel(context);
+
       // 新しいファイルが開かれた時の初期解析
       const { runAnalysis } = await import('./features/analyzer');
       await runAnalysis(editor.document);
-
-      // The new analyzer automatically sends updates to the panel, so this is not needed.
     } catch (error) {
       console.warn('[CriticalWritingJp] Error in active editor change handler:', error);
     }

--- a/src/features/analyzer.ts
+++ b/src/features/analyzer.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { DisposableStore } from '../platform/disposable-store';
 import { Paragraph, ParagraphType, AnalysisResult } from '../core/types';
 import { normalizeText, countChars, sha1, debounce } from '../core/utils';
+import { WebviewPanel } from '../features/webview-panel';
 import { keywordEngine } from './keyword-engine';
 import { roiEngine } from './roi-engine';
 import { styleChecker } from './style-checker';
@@ -20,6 +21,8 @@ let diagnosticCollection: vscode.DiagnosticCollection;
 let statusBarItem: vscode.StatusBarItem | undefined;
 // 拡張機能本体から渡されるDisposableStore
 let analyzerDisposables: DisposableStore | undefined;
+// 拡張機能のコンテキスト
+let extensionContext: vscode.ExtensionContext;
 
 /**
  * テキスト変更イベントの処理
@@ -105,6 +108,20 @@ async function performAnalysis(document: vscode.TextDocument): Promise<AnalysisR
     // 診断情報を更新
     updateDiagnostics(document, styleViolations, citationViolations);
     
+    // Webviewパネルに解析結果を送信
+    if (extensionContext) {
+      const panel = WebviewPanel.getInstance(extensionContext);
+      const panelUpdateData = {
+        paragraphs: result.paragraphs,
+        statistics: {
+          totalCount: result.paragraphs.length,
+        },
+      };
+      // updateWithAnalysisResult は ParagraphAnalysisResult 型を期待するが、
+      // 構造が互換なのでそのまま渡す
+      panel.updateWithAnalysisResult(panelUpdateData as any);
+    }
+
     return result;
   } catch (error) {
     const elapsedTime = Date.now() - startTime;
@@ -733,6 +750,7 @@ export async function initializeAnalyzer(
   context: vscode.ExtensionContext,
   disposables: DisposableStore
 ): Promise<void> {
+  extensionContext = context;
   analyzerDisposables = disposables;
   try {
     // 診断情報コレクションを作成


### PR DESCRIPTION
Markdownまたはplaintextファイルを開いた際に、分析パネルが自動的に表示されるように修正しました。

以前は、ファイルを開いても解析が実行されるだけで、パネルの表示は手動で行う必要がありました。この修正により、`onDidChangeActiveTextEditor`イベントハンドラ内で`createOrShowPanel`を呼び出すことで、対象ファイルを開いた際にパネルが確実に表示されるようになります。

また、解析完了後にWebviewへ結果を送信する処理も確実に行うようにし、パネル表示とデータ更新が連携して行われるようにしました。