### PR TITLE
feat: 分析パネルの表示とUIコンポーネントの復元

### DIFF
--- a/src/core/ipc-types.ts
+++ b/src/core/ipc-types.ts
@@ -85,11 +85,23 @@ export interface PanelUpdate {
       /** 総段落数 */
       total: number;
       
+      /** 総文字数 */
+      chars: number;
+
       /** 閾値超過段落数 */
       over: number;
       
       /** 閾値未満段落数 */
       under: number;
+    };
+
+    /** グラフ用データ */
+    charts: {
+      /** 文字種バランス */
+      charBalance: { name: string; value: number }[];
+
+      /** 常用漢字の使用率 */
+      joyoKanji: { name: string; value: number }[];
     };
     
     /** 段落ごとの詳細データ */

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,19 +59,12 @@ export function activate(context: vscode.ExtensionContext) {
         const editor = vscode.window.activeTextEditor;
         if (editor && (editor.document.languageId === 'markdown' || editor.document.languageId === 'plaintext') && !editor.document.isClosed) {
           lastActiveMarkdownEditor = editor;
-          const { runAnalysis } = await import('./features/analyzer');
-          await runAnalysis(editor.document);
-
-          // The new panel doesn't have an `updatePanel` export, but we can get the instance
-          // and call a method on it if we expose one. For now, let's assume showing it is enough.
-        }
-
-        // VSCode起動時にパネルを自動表示（横に表示しフォーカスは保持）
-        try {
+          // 先にパネルを表示
           const { createOrShowPanel } = await import('./features/webview-panel');
           await createOrShowPanel(context);
-        } catch (e) {
-          console.warn('[CriticalWritingJp] Failed to auto-open panel on startup:', e);
+          // 次に解析を実行
+          const { runAnalysis } = await import('./features/analyzer');
+          await runAnalysis(editor.document);
         }
       } catch (error) {
         console.error('[CriticalWritingJp] Failed to initialize analyzer:', error);
@@ -337,6 +330,15 @@ function registerCommands(store: DisposableStore, context: vscode.ExtensionConte
   } catch (error) {
     console.warn('[CriticalWritingJp] Command already registered: criticalWritingJp.jumpToParagraphAndShowPanel');
   }
+
+  try {
+    store.add(vscode.commands.registerCommand('criticalWritingJp.dnd-reorder', async (payload: string[]) => {
+      console.log('[Extension] dnd-reorder command executed with payload:', payload);
+      // Placeholder for reordering logic
+    }));
+  } catch (error) {
+    console.warn('[CriticalWritingJp] Command already registered: criticalWritingJp.dnd-reorder');
+  }
 }
 
 /**
@@ -389,11 +391,13 @@ function registerTextDocumentHandlers(store: DisposableStore, context: vscode.Ex
       }
       lastActiveMarkdownEditor = editor;
 
+      // パネルを表示
+      const { createOrShowPanel } = await import('./features/webview-panel');
+      await createOrShowPanel(context);
+
       // 新しいファイルが開かれた時の初期解析
       const { runAnalysis } = await import('./features/analyzer');
       await runAnalysis(editor.document);
-
-      // The new analyzer automatically sends updates to the panel, so this is not needed.
     } catch (error) {
       console.warn('[CriticalWritingJp] Error in active editor change handler:', error);
     }

--- a/src/features/analyzer.ts
+++ b/src/features/analyzer.ts
@@ -2,7 +2,9 @@ import * as vscode from 'vscode';
 import { DisposableStore } from '../platform/disposable-store';
 import { Paragraph, ParagraphType, AnalysisResult } from '../core/types';
 import { normalizeText, countChars, sha1, debounce } from '../core/utils';
+import { WebviewPanel } from '../features/webview-panel';
 import { keywordEngine } from './keyword-engine';
+import { isJoyo } from 'joyo-kanji';
 import { roiEngine } from './roi-engine';
 import { styleChecker } from './style-checker';
 import { citationChecker } from './citation-checker';
@@ -20,6 +22,8 @@ let diagnosticCollection: vscode.DiagnosticCollection;
 let statusBarItem: vscode.StatusBarItem | undefined;
 // 拡張機能本体から渡されるDisposableStore
 let analyzerDisposables: DisposableStore | undefined;
+// 拡張機能のコンテキスト
+let extensionContext: vscode.ExtensionContext;
 
 /**
  * テキスト変更イベントの処理
@@ -51,6 +55,57 @@ export async function runAnalysis(document: vscode.TextDocument): Promise<Analys
     console.error('[Analyzer] Analysis failed:', error);
     return undefined;
   }
+}
+
+function calculateOverallStats(paragraphs: Paragraph[]) {
+  const allText = paragraphs.map(p => p.text).join('');
+  const totalChars = allText.length;
+
+  let hiragana = 0;
+  let katakana = 0;
+  let kanji = 0;
+  let other = 0;
+  let joyo = 0;
+  let nonJoyo = 0;
+
+  for (const char of allText) {
+    if (char.match(/[\u3040-\u309F]/)) {
+      hiragana++;
+    } else if (char.match(/[\u30A0-\u30FF]/)) {
+      katakana++;
+    } else if (char.match(/[\u4E00-\u9FAF]/)) {
+      kanji++;
+      if (isJoyo(char)) {
+        joyo++;
+      } else {
+        nonJoyo++;
+      }
+    } else {
+      other++;
+    }
+  }
+
+  const charBalance = [
+    { name: 'ひらがな', value: hiragana / totalChars },
+    { name: 'カタカナ', value: katakana / totalChars },
+    { name: '漢字', value: kanji / totalChars },
+    { name: 'その他', value: other / totalChars },
+  ];
+
+  const joyoKanji = [
+    { name: '常用漢字', value: joyo / (joyo + nonJoyo || 1) },
+    { name: '常用外漢字', value: nonJoyo / (joyo + nonJoyo || 1) },
+  ];
+
+  return {
+    summary: {
+      chars: totalChars,
+    },
+    charts: {
+      charBalance,
+      joyoKanji,
+    }
+  };
 }
 
 /**
@@ -105,6 +160,23 @@ async function performAnalysis(document: vscode.TextDocument): Promise<AnalysisR
     // 診断情報を更新
     updateDiagnostics(document, styleViolations, citationViolations);
     
+    // Webviewパネルに解析結果を送信
+    if (extensionContext) {
+      const overallStats = calculateOverallStats(result.paragraphs);
+      const panel = WebviewPanel.getInstance(extensionContext);
+      const panelUpdateData = {
+        paragraphs: result.paragraphs,
+        statistics: {
+          totalCount: result.paragraphs.length,
+          chars: overallStats.summary.chars,
+        },
+        charts: overallStats.charts,
+      };
+      // updateWithAnalysisResult は ParagraphAnalysisResult 型を期待するが、
+      // 構造が互換なのでそのまま渡す
+      panel.updateWithAnalysisResult(panelUpdateData as any);
+    }
+
     return result;
   } catch (error) {
     const elapsedTime = Date.now() - startTime;
@@ -733,6 +805,7 @@ export async function initializeAnalyzer(
   context: vscode.ExtensionContext,
   disposables: DisposableStore
 ): Promise<void> {
+  extensionContext = context;
   analyzerDisposables = disposables;
   try {
     // 診断情報コレクションを作成

--- a/src/features/webview-panel.ts
+++ b/src/features/webview-panel.ts
@@ -80,7 +80,7 @@ export class WebviewPanel {
    * 分析結果でパネルを更新
    */
   async updateWithAnalysisResult(
-    result: ParagraphAnalysisResult,
+    result: ParagraphAnalysisResult & { charts: any }, // Add charts to the type
     llmResults?: Map<string, LLMEvaluationResult>,
     booksResults?: Map<string, GoogleBooksResult[]>
   ): Promise<void> {
@@ -97,22 +97,26 @@ export class WebviewPanel {
       payload: {
         summary: {
           total: result.statistics.totalCount,
+          chars: (result.statistics as any).chars || 0,
           over: result.paragraphs.filter(p => p.chars > maxThreshold).length,
           under: result.paragraphs.filter(p => p.chars < minThreshold).length
         },
+        charts: result.charts,
         rows: result.paragraphs.map(paragraph => {
           const llmResult = llmResults?.get(paragraph.id);
-          const booksResult = booksResults?.get(paragraph.id);
-
-          return {
+          const rowData: any = {
             id: paragraph.id,
             head: this.truncateText(paragraph.text, settings.ui.preview.headChars),
             chars: paragraph.chars,
             kw: this.extractKeywords(paragraph),
-            roi: paragraph.features?.roi,
-            llm: llmResult ? (llmResult.style + llmResult.argumentation) / 2 : undefined,
-            features: paragraph.features, // Pass through the features for charts
           };
+          if (paragraph.features?.roi !== undefined) {
+            rowData.roi = paragraph.features.roi;
+          }
+          if (llmResult) {
+            rowData.llm = (llmResult.style + llmResult.argumentation) / 2;
+          }
+          return rowData;
         })
       }
     };
@@ -144,6 +148,16 @@ export class WebviewPanel {
 
       case 'refreshAnalysis':
         await vscode.commands.executeCommand('criticalWritingJp.runKeywordNow');
+        break;
+
+      case 'toggleKeywordHighlight':
+        console.log('[WebviewPanel] Received toggleKeywordHighlight command:', message.enabled);
+        // Placeholder for actual implementation
+        break;
+
+      case 'reorderParagraphs':
+        console.log('[WebviewPanel] Received reorderParagraphs command:', message.payload);
+        await vscode.commands.executeCommand('criticalWritingJp.dnd-reorder', message.payload);
         break;
 
       default:
@@ -243,7 +257,7 @@ export class WebviewPanel {
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="
         default-src 'none';
-        style-src ${webview.cspSource} 'unsafe-inline';
+        style-src ${webview.cspSource} https://fonts.googleapis.com 'unsafe-inline';
         script-src 'nonce-${nonce}';
         img-src ${webview.cspSource} data:;
         font-src https://fonts.gstatic.com;

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import AnalysisStats from './components/AnalysisStats';
 import ParagraphDashboard from './components/ParagraphDashboard';
+import CharacterBalanceChart from './components/CharacterBalanceChart';
+import KanjiUsageChart from './components/KanjiUsageChart';
 import vscodeApi from './vscodeApi';
 
 const App = () => {
@@ -11,7 +13,7 @@ const App = () => {
     const newState = !highlighting;
     setHighlighting(newState);
     vscodeApi.postMessage({
-      type: 'toggleKeywordHighlight',
+      command: 'toggleKeywordHighlight',
       enabled: newState,
     });
   };
@@ -54,11 +56,22 @@ const App = () => {
         <>
           <section className="section">
             <h2 className="section-title">全体サマリー</h2>
-            <AnalysisStats
-              paragraphCount={analysisData.summary.total}
-              overLimitCount={analysisData.summary.over}
-              underLimitCount={analysisData.summary.under}
-            />
+            <div className="summary-grid">
+              <AnalysisStats
+                paragraphCount={analysisData.summary.total}
+                overLimitCount={analysisData.summary.over}
+                underLimitCount={analysisData.summary.under}
+                charCount={analysisData.summary.chars}
+              />
+              <div className="chart-container">
+                <h3 className="chart-title">文字種バランス</h3>
+                <CharacterBalanceChart data={analysisData.charts.charBalance} />
+              </div>
+              <div className="chart-container">
+                <h3 className="chart-title">常用漢字の割合</h3>
+                <KanjiUsageChart data={analysisData.charts.joyoKanji} />
+              </div>
+            </div>
           </section>
 
           <section className="section">


### PR DESCRIPTION
ユーザーから報告された複数の問題を修正しました。

- MDファイルを開いた際に分析パネルが自動で表示されない問題を修正。
- 起動時にファイルが開いている場合もパネルが表示されるように修正。
- 欠落していた「全体サマリー」と各種円グラフを復元。
- WebviewのCSPを修正し、Google Fontsが正しく読み込まれるようにした。
- D&D（ドラッグアンドドロップ）機能のメッセージングを修正。

主な変更点：
- `extension.ts`: ファイルを開いた際と起動時にパネルを表示するロジックを追加。
- `analyzer.ts`: 全体サマリーとグラフ用の統計情報を計算するロジックを追加。
- `webview-panel.ts`: 拡張機能とWebview間のデータ受け渡しを更新。
- `App.tsx`: 欠落していたUIコンポーネントを再追加。
- `ipc-types.ts`: Webviewに渡すデータの型定義を更新。

注意：段落のD&D機能については、UIと拡張機能間の通信は確立しましたが、実際のテキスト編集ロジックは未実装です。これは今後の課題となります。