### PR TITLE
fix: analyzer.tsの構文エラーを修正

### DIFF
--- a/src/features/analyzer.ts
+++ b/src/features/analyzer.ts
@@ -148,7 +148,7 @@ function detectPlaintextParagraphs(document: vscode.TextDocument): Paragraph[] {
         const paragraphData = {
           lines: currentParagraphLines,
           startOffset: paragraphStartOffset,
-          type: ParagraphType.Normal,
+          type: ParagraphType.Normal
         };
         finalizeParagraph(paragraphData, currentOffset, paragraphs);
       }


### PR DESCRIPTION
esbuildでビルドが失敗する原因となっていた、`src/features/analyzer.ts`内のオブジェクトリテラルの末尾にある余分なカンマを削除しました。

これにより、`Expected identifier but found "}"`というエラーが解消され、ビルドが正常に完了するようになります。