### PR TITLE
fix(build): analyzer.tsの構文エラーを修正

### DIFF
--- a/src/features/analyzer.ts
+++ b/src/features/analyzer.ts
@@ -164,7 +164,7 @@ function detectPlaintextParagraphs(document: vscode.TextDocument): Paragraph[] {
         const paragraphData = {
           lines: currentParagraphLines,
           startOffset: paragraphStartOffset,
-          type: ParagraphType.Normal,
+          type: ParagraphType.Normal
         };
         finalizeParagraph(paragraphData, currentOffset, paragraphs);
         currentParagraphLines = [];


### PR DESCRIPTION
`esbuild`でビルドが失敗する原因となっていた、`src/features/analyzer.ts`内のオブジェクトリテラルの末尾にある余分なカンマを削除しました。

この修正により、`Expected identifier but found "}"`というエラーが解消され、ビルドが正常に完了するようになります。